### PR TITLE
ensure payload_len is zeroed on start of a new multi-frame packet

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -454,6 +454,7 @@ int16_t canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, ui
 
         // take off the crc and store the payload
         rx_state->timestamp_usec = timestamp_usec;
+        rx_state->payload_len = 0;
         const int16_t ret = bufferBlockPushBytes(&ins->allocator, rx_state, frame->data + 2,
                                                  (uint8_t) (frame->data_len - 3));
         if (ret < 0)


### PR DESCRIPTION
this ensures that we don't use payload bytes from rejected frames